### PR TITLE
Fix NullReferenceException

### DIFF
--- a/XlsxToHtmlConverter/XlsxToHtmlConverter/Converter.cs
+++ b/XlsxToHtmlConverter/XlsxToHtmlConverter/Converter.cs
@@ -435,7 +435,7 @@ namespace XlsxToHtmlConverter
                     WorkbookPart workbook = doc.WorkbookPart;
                     WorkbookStylesPart styles = workbook.WorkbookStylesPart;
                     IEnumerable<Sheet> sheets = workbook.Workbook.Descendants<Sheet>();
-                    SharedStringTable sharedStringTable = workbook.GetPartsOfType<SharedStringTablePart>().FirstOrDefault().SharedStringTable;
+                    SharedStringTable sharedStringTable = workbook.GetPartsOfType<SharedStringTablePart>().FirstOrDefault()?.SharedStringTable;
 
                     progressCallbackEvent?.Invoke(doc, new ConverterProgressCallbackEventArgs(0, sheets.Count()));
 


### PR DESCRIPTION
Trying to convert a XLSX file generated by [Open-XML-SDK](https://github.com/officedev/open-xml-sdk) (as opposed to one created by Excel) is causing a `NullReferenceException`, because that file's `Workbook` doesn't have any parts of type `SharedStringTable`.

The code used to generate this XLSX file is based on [this StackOverflow answer](https://stackoverflow.com/a/44588074/1578975).