### PR TITLE
Add support for configurable row and column rendering ranges

### DIFF
--- a/XlsxToHtmlConverter/Converter.cs
+++ b/XlsxToHtmlConverter/Converter.cs
@@ -336,7 +336,6 @@ namespace XlsxToHtmlConverter
                         }
                     }
 
-                    colStart = configuration.ColsToRender?.Start ?? context.Sheet.Dimension.ColumnStart;
                     uint colIndex = cell.Reference.Column - colStart;
                     Base.Specification.Xlsx.XlsxBaseStyles? shared = Base.Implementation.Common.Get(context.Stylesheet.BaseStyles, cell.Cell?.StyleIndex?.Value ?? Base.Implementation.Common.Get(columns, colIndex).StylesIndex ?? row?.StyleIndex?.Value ?? 0);
                     if (shared != null)

--- a/XlsxToHtmlConverter/Converter.cs
+++ b/XlsxToHtmlConverter/Converter.cs
@@ -187,10 +187,15 @@ namespace XlsxToHtmlConverter
                 writer.Write(converter(configuration.ConverterComposition.HtmlWriter, new(indent, Base.Specification.Html.HtmlElementType.PairedStart, "colgroup")));
                 indent++;
 
-                (double Width, bool? IsHidden, uint? StylesIndex)[] columns = new (double Width, bool? IsHidden, uint? StylesIndex)[context.Sheet.Dimension.ColumnCount];
-                for (uint i = 0; i < columns.Length; i++)
+                uint colStart = configuration.ColsToRender?.Start ?? context.Sheet.Dimension.ColumnStart;
+                uint colEnd = configuration.ColsToRender?.End ?? context.Sheet.Dimension.ColumnEnd;
+                uint colCount = colEnd - colStart + 1;
+
+                (double Width, bool? IsHidden, uint? StylesIndex)[] columns = new (double Width, bool? IsHidden, uint? StylesIndex)[colCount];
+                for (uint i = 0; i < colCount; i++)
                 {
-                    (double? width, bool? isHidden, uint? styles) = Base.Implementation.Common.Get(context.Sheet.Columns, i);
+                    uint colIndex = colStart + i - context.Sheet.Dimension.ColumnStart;
+                    (double? width, bool? isHidden, uint? styles) = Base.Implementation.Common.Get(context.Sheet.Columns, colIndex);
                     columns[i] = (width ?? context.Sheet.CellSize.Width, isHidden, styles);
                 }
                 if (configuration.UseHtmlProportionalWidths)
@@ -225,7 +230,7 @@ namespace XlsxToHtmlConverter
                 writer.Write(converter(configuration.ConverterComposition.HtmlWriter, new(indent, Base.Specification.Html.HtmlElementType.PairedStart, "tbody")));
                 indent++;
 
-                (uint Column, uint Row) last = (context.Sheet.Dimension.ColumnStart - 1, context.Sheet.Dimension.RowStart - 1);
+                (uint Column, uint Row) last = ((configuration.ColsToRender?.Start ?? context.Sheet.Dimension.ColumnStart) - 1, (configuration.RowsToRender?.Start ?? context.Sheet.Dimension.RowStart) - 1);
                 List<Base.Specification.Xlsx.XlsxSpecialty> specialties = [];
 
                 void content(uint column, uint row, Base.Specification.Html.HtmlElement? element = null)
@@ -244,7 +249,7 @@ namespace XlsxToHtmlConverter
                         return;
                     }
 
-                    for (uint i = last.Column + 1; i <= context.Sheet.Dimension.ColumnEnd; i++)
+                    for (uint i = last.Column + 1; i <= colEnd; i++)
                     {
                         content(i, last.Row);
                     }
@@ -264,11 +269,39 @@ namespace XlsxToHtmlConverter
                         continue;
                     }
 
+                    // Skip rows before the range starts
+                    if (configuration.RowsToRender != null && cell.Reference.Row < configuration.RowsToRender?.Start)
+                    {
+                        continue;
+                    }
+
+                    // Stop processing once we've passed the end of the range
+                    if (configuration.RowsToRender != null && cell.Reference.Row > configuration.RowsToRender?.End)
+                    {
+                        break;
+                    }
+
+                    // Skip columns before the range starts
+                    if (configuration.ColsToRender != null && cell.Reference.Column < configuration.ColsToRender?.Start)
+                    {
+                        continue;
+                    }
+
+                    // Skip columns after the range ends
+                    if (configuration.ColsToRender != null && cell.Reference.Column > configuration.ColsToRender?.End)
+                    {
+                        continue;
+                    }
+
                     while (cell.Reference.Row > last.Row)
                     {
-                        suffix();
+                        // Only call suffix if we've already created a row
+                        if (last.Row >= (configuration.RowsToRender?.Start ?? context.Sheet.Dimension.RowStart))
+                        {
+                            suffix();
+                        }
 
-                        last = (context.Sheet.Dimension.ColumnStart - 1, last.Row + 1);
+                        last = ((configuration.ColsToRender?.Start ?? context.Sheet.Dimension.ColumnStart) - 1, last.Row + 1);
                         specialties = Base.Implementation.Common.Get(references, last.Row) ?? [];
                         row = cell.Reference.Row <= last.Row ? cell.Cell?.Parent as Row : null;
 
@@ -297,10 +330,15 @@ namespace XlsxToHtmlConverter
                     }
                     for (uint i = last.Column + 1; i < cell.Reference.Column; i++)
                     {
-                        content(i, cell.Reference.Row);
+                        if (i >= colStart && i <= colEnd)
+                        {
+                            content(i, cell.Reference.Row);
+                        }
                     }
 
-                    Base.Specification.Xlsx.XlsxBaseStyles? shared = Base.Implementation.Common.Get(context.Stylesheet.BaseStyles, cell.Cell?.StyleIndex?.Value ?? Base.Implementation.Common.Get(columns, cell.Reference.Column - context.Sheet.Dimension.ColumnStart).StylesIndex ?? row?.StyleIndex?.Value ?? 0);
+                    colStart = configuration.ColsToRender?.Start ?? context.Sheet.Dimension.ColumnStart;
+                    uint colIndex = cell.Reference.Column - colStart;
+                    Base.Specification.Xlsx.XlsxBaseStyles? shared = Base.Implementation.Common.Get(context.Stylesheet.BaseStyles, cell.Cell?.StyleIndex?.Value ?? Base.Implementation.Common.Get(columns, colIndex).StylesIndex ?? row?.StyleIndex?.Value ?? 0);
                     if (shared != null)
                     {
                         cell.Styles.Add(shared);
@@ -361,7 +399,11 @@ namespace XlsxToHtmlConverter
 
                     last = cell.Reference;
                 }
-                suffix();
+                // Only call suffix if we have valid rows to close
+                if (configuration.RowsToRender == null || last.Row >= configuration.RowsToRender?.Start)
+                {
+                    suffix();
+                }
 
                 if (elements.Any())
                 {

--- a/XlsxToHtmlConverter/ConverterConfiguration.cs
+++ b/XlsxToHtmlConverter/ConverterConfiguration.cs
@@ -225,5 +225,37 @@ namespace XlsxToHtmlConverter
         /// Gets or sets whether to utilize the HTML machine-readable elements.
         /// </summary>
         public bool UseHtmlDataElements { get; set; } = true;
+
+        public Range? RowsToRender { get; set; } = null;
+        public Range? ColsToRender { get; set; } = null;
+
+        public struct Range
+        {
+            public uint Start { get; set; }
+
+            public uint End { get; set; }
+
+            public Range(uint start, uint end)
+            {
+                if (start < 1)
+                {
+                    throw new ArgumentException("Start row cannot be less than 1.", nameof(start));
+                }
+                if (start > end)
+                {
+                    throw new ArgumentException("Start row cannot be greater than end row.", nameof(start));
+                }
+
+                Start = start;
+                End = end;
+            }
+
+            public readonly bool Contains(uint row)
+            {
+                return row >= Start && row <= End;
+            }
+
+            public readonly uint Count => End - Start + 1;
+        }
     }
 }


### PR DESCRIPTION
Thank you for sharing great library.

Add possibility to have settings like

```
Converter.Convert(xlsx, html, new()
{
    HtmlTitle = Path.GetFileName(xlsx),
    XlsxSheetSelector = (sheetInfo) => sheetInfo.Index == 3,
    RowsToRender = new ConverterConfiguration.Range(1, 50),
    ColsToRender = new ConverterConfiguration.Range(1, 50),
   ...
```